### PR TITLE
fix: wrap repos menu label in menu group

### DIFF
--- a/apps/desktop/src/components/header.tsx
+++ b/apps/desktop/src/components/header.tsx
@@ -11,6 +11,7 @@ import { Button } from "./ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -98,7 +99,9 @@ export default function Header() {
             }
           />
           <DropdownMenuContent align="start" sideOffset={8} className="w-[360px] rounded-md">
-            <DropdownMenuLabel>Viewed repositories</DropdownMenuLabel>
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>Viewed repositories</DropdownMenuLabel>
+            </DropdownMenuGroup>
             <DropdownMenuSeparator />
             {opened_repos.length ? (
               opened_repos.map((openedRepoPath) => (


### PR DESCRIPTION
## Summary
- wrap the repos dropdown label with `DropdownMenuGroup` so `DropdownMenuLabel` is used within the required Base UI menu group context
- fix the runtime crash (`Base UI error #31`) that happened when clicking the Repos button in the header
- keep the change scoped to the header menu composition only

## Testing
- bun run --cwd \"apps/desktop\" check-types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured header UI component organization to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->